### PR TITLE
fix: update workflow to include main branch in push triggers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,19 +3,17 @@ name: Tests & Coverage
 on:
   workflow_dispatch:
   push:
-    branches: [ feature/*, hotfix/* ]
+    branches: [ main, feature/*, hotfix/* ]
     paths:
       - '**/*.py'
       - 'requirements.txt'
       - '.github/workflows/tests.yml'
-      - '.github/workflows/release.yml'
   pull_request:
     branches: [ main ]
     paths:
       - '**/*.py'
       - 'requirements.txt'
       - '.github/workflows/tests.yml'
-      - '.github/workflows/release.yml'
 
 jobs:
   tests:


### PR DESCRIPTION
- Add main to push branches to match target branch expectations
- Remove release.yml from path triggers for cleaner triggering
- Ensures workflows trigger properly on PRs to main