### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/volkswagen_goconnect/api.py
+++ b/custom_components/volkswagen_goconnect/api.py
@@ -406,7 +406,11 @@ class VolkswagenGoConnectApiClient:
                         if HTTP_DEBUG:
                             _LOGGER.debug("Data: %s", _sanitize_mapping(data))
                         else:
-                            _LOGGER.debug("Request data keys: %s", list(data.keys()))
+                            sanitized_keys = [
+                                _redacted() if str(k).lower() in SENSITIVE_KEYS else k
+                                for k in data.keys()
+                            ]
+                            _LOGGER.debug("Request data keys: %s", sanitized_keys)
                     elif data is not None:
                         _LOGGER.debug("Request has non-dict JSON body")
 


### PR DESCRIPTION
Potential fix for [https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/13](https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/13)

General approach: ensure that any data derived from sensitive inputs is sanitized before being logged. The code already has `_sanitize_mapping` that redacts values for keys in `SENSITIVE_KEYS`. We should apply a similar sanitization to the keys we log when `HTTP_DEBUG` is false, so that keys like `"password"`, `"token"`, etc., are not emitted in the clear. Instead of logging `list(data.keys())` directly, we can log a sanitized list of keys where sensitive ones are replaced with a redacted marker.

Best concrete fix: modify the `_api_wrapper` method in `custom_components/volkswagen_goconnect/api.py` at the branch where `isinstance(data, dict)` and `HTTP_DEBUG` is `False`. Replace:

```python
else:
    _LOGGER.debug("Request data keys: %s", list(data.keys()))
```

with code that builds a sanitized list of keys:

```python
else:
    sanitized_keys = [
        _redacted() if str(k).lower() in SENSITIVE_KEYS else k
        for k in data.keys()
    ]
    _LOGGER.debug("Request data keys: %s", sanitized_keys)
```

This leverages the existing `SENSITIVE_KEYS` and `_redacted()` so it keeps behavior consistent with other sanitization paths. Non-sensitive keys are logged as before; sensitive key names are replaced with `"***REDACTED***"`. No functional API behavior changes; only log contents are altered. No changes are necessary in `config_flow.py` because it only passes the password to the client and does not itself perform any logging.

Implementation details:

- File: `custom_components/volkswagen_goconnect/api.py`.
- Region: `_api_wrapper` in the `if isinstance(data, dict)` block (around line 405–410).
- No new imports, methods, or constants are required; we reuse `SENSITIVE_KEYS` and `_redacted()` already defined at the top of the same file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
