### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/volkswagen_goconnect/api.py
+++ b/custom_components/volkswagen_goconnect/api.py
@@ -403,10 +403,13 @@ class VolkswagenGoConnectApiClient:
                     _LOGGER.debug("Headers: %s", _sanitize_headers(headers))
 
                     if isinstance(data, dict):
-                        if HTTP_DEBUG:
-                            _LOGGER.debug("Data: %s", _sanitize_mapping(data))
-                        else:
-                            _LOGGER.debug("Request data keys: %s", list(data.keys()))
+                        # Do not log full request bodies to avoid leaking sensitive data
+                        keys = list(data.keys())
+                        _LOGGER.debug(
+                            "Request data keys (%d): %s",
+                            len(keys),
+                            keys,
+                        )
                     elif data is not None:
                         _LOGGER.debug("Request has non-dict JSON body")
 


### PR DESCRIPTION
Potential fix for [https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/12](https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/12)

General approach: avoid logging structures that may contain sensitive information (passwords, tokens, etc.) and/or ensure that anything logged is robustly redacted. Since the taint analysis complains specifically about `_sanitize_mapping(data)` being passed into the logger, the safest fix is to stop logging the full `data` payload and instead log only non‑sensitive metadata (like keys, lengths, or a fixed message) in both normal and debug modes. This removes the direct dependency on our custom sanitizer for credentials, while still keeping useful debug information.

Best concrete fix here:

- In `VolkswagenGoConnectApiClient._api_wrapper` within `custom_components/volkswagen_goconnect/api.py`, change the code that currently logs the full `data` mapping when `HTTP_DEBUG` is enabled.
- Instead of `_LOGGER.debug("Data: %s", _sanitize_mapping(data))`, log only high‑level, non‑sensitive info such as the list of keys and the size of the body. This preserves functionality (HTTP requests still behave the same) while reducing log verbosity.
- The rest of the sanitizer functions and constants (`SENSITIVE_KEYS`, `_sanitize_mapping`, `_sanitize_headers`, `_sanitize_url`) can remain as helpful extra protection for headers/URLs and any other future use, but they will no longer be on the tainted path flagged by CodeQL.
- No changes are needed in `config_flow.py`; it doesn’t log the password itself, only passes it down to the API client.

Concretely:

- Edit `custom_components/volkswagen_goconnect/api.py` at the block around lines 405–411 to remove the call to `_sanitize_mapping(data)` and replace it with a debug log like `"Request data keys: %s"` in both branches, optionally including the number of keys to keep `HTTP_DEBUG` useful.
- Leave all other behavior (request construction, exception handling, throttling, etc.) unchanged.

No new imports or helper methods are required; we only modify the logging call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
