### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/volkswagen_goconnect/api.py
+++ b/custom_components/volkswagen_goconnect/api.py
@@ -403,12 +403,15 @@ class VolkswagenGoConnectApiClient:
                     _LOGGER.debug("Headers: %s", _sanitize_headers(headers))
 
                     if isinstance(data, dict):
-                        # Do not log full request bodies to avoid leaking sensitive data
-                        keys = list(data.keys())
+                        # Do not log full request bodies or sensitive keys to avoid leaking sensitive data
+                        total_keys = len(data)
+                        non_sensitive_keys = [
+                            k for k in data.keys() if str(k).lower() not in SENSITIVE_KEYS
+                        ]
                         _LOGGER.debug(
-                            "Request data keys (%d): %s",
-                            len(keys),
-                            keys,
+                            "Request data keys: %d total, non-sensitive keys: %s",
+                            total_keys,
+                            non_sensitive_keys,
                         )
                     elif data is not None:
                         _LOGGER.debug("Request has non-dict JSON body")


### PR DESCRIPTION
Potential fix for [https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/16](https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/16)

To fix the problem, we should ensure that no log entry contains identifiers that static analysis (and policy) consider sensitive, such as the `"password"` key. Since we already avoid logging full request bodies and sanitize values elsewhere, the minimal change is to avoid logging the raw `keys` list from `data`, or to filter out keys that match `SENSITIVE_KEYS` before logging.

Best single fix without changing functionality: in `_api_wrapper` in `custom_components/volkswagen_goconnect/api.py`, adjust the debug logging for request data when `data` is a `dict`. Instead of logging `keys = list(data.keys())` and then logging `keys`, compute a list of non-sensitive keys (excluding any whose lowercase name is in `SENSITIVE_KEYS`) and log only those keys and the total number of keys. This keeps the behavior (informing developers that there is a JSON body and roughly what is in it) while ensuring sensitive field names are not logged. The rest of the code, including how requests are sent and how authentication works, remains unchanged.

Concretely:
- In `_api_wrapper`, replace the current block:

  ```python
  if isinstance(data, dict):
      # Do not log full request bodies to avoid leaking sensitive data
      keys = list(data.keys())
      _LOGGER.debug(
          "Request data keys (%d): %s",
          len(keys),
          keys,
      )
  ```

  with something like:

  ```python
  if isinstance(data, dict):
      total_keys = len(data)
      non_sensitive_keys = [
          k for k in data.keys() if str(k).lower() not in SENSITIVE_KEYS
      ]
      _LOGGER.debug(
          "Request data keys: %d total, non-sensitive keys: %s",
          total_keys,
          non_sensitive_keys,
      )
  ```

- This uses existing `SENSITIVE_KEYS` and does not require new imports or helpers.
- No changes are needed in `config_flow.py`, because the leak is solely through the logging in `_api_wrapper`; the password is only stored and passed, not logged there.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
