### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/volkswagen_goconnect/api.py
+++ b/custom_components/volkswagen_goconnect/api.py
@@ -405,16 +405,12 @@ class VolkswagenGoConnectApiClient:
                     if isinstance(data, dict):
                         # Do not log full request bodies or sensitive keys to avoid leaking sensitive data
                         total_keys = len(data)
-                        non_sensitive_keys = [
-                            k for k in data.keys() if str(k).lower() not in SENSITIVE_KEYS
-                        ]
                         _LOGGER.debug(
-                            "Request data keys: %d total, non-sensitive keys: %s",
+                            "Request data keys: %d total (body content not logged)",
                             total_keys,
-                            non_sensitive_keys,
                         )
                     elif data is not None:
-                        _LOGGER.debug("Request has non-dict JSON body")
+                        _LOGGER.debug("Request has non-dict JSON body (content not logged)")
 
                     response = await self._session.request(
                         method=method,


### PR DESCRIPTION
Potential fix for [https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/17](https://github.com/amoisis/volkswagen_goconnect/security/code-scanning/17)

To eliminate the warning and further reduce risk, we should stop including any information derived from the request body (`data`) in debug logs when that body may contain sensitive fields like `password`. Instead of logging `non_sensitive_keys`, we can either (a) log only aggregate counts (e.g., how many keys, whether a body is present), or (b) log nothing about the body at all. This preserves functionality while ensuring that passwords or their associated key names never influence log contents.

The minimal, best fix here is in `custom_components/volkswagen_goconnect/api.py` inside `_api_wrapper`: replace the computation and logging of `non_sensitive_keys` with a simple log of the total number of keys present, or just a generic message. For example, keep `total_keys = len(data)` (which is not sensitive) and log `"Request data keys: %d total"` without listing the keys. This change removes the tainted `non_sensitive_keys` variable from the log statement and should address all the variants flagged at this location.

No changes are required in `config_flow.py`, because there is no explicit logging of the password or data derived from it there; the sanitizer work is all in the API client.

Concretely:
- In `api.py`, in `_api_wrapper` around lines 405–415, remove the `non_sensitive_keys` list comprehension and the `%s` placeholder that logs it, and replace with a log that reports only `total_keys`. Keep the rest of the logic intact.
- No additional imports or helper methods are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
